### PR TITLE
adding ability to put empty lists and maps

### DIFF
--- a/src/DynamoDb.Ok/Library.fs
+++ b/src/DynamoDb.Ok/Library.fs
@@ -49,8 +49,8 @@ module private AttrMapping =
         | SetDecimal sd -> A(NS = ResizeArray(Seq.map string (toSet sd)))
         | SetInt32 si -> A(NS = ResizeArray(Seq.map string (toSet si)))
         | SetBinary bs -> A(BS = ResizeArray(Seq.map toGzipMemoryStream (toSet bs)))
-        | DocList l -> A(L = ResizeArray(List.map mapAttrValue l))
-        | DocMap m -> A(M = mapAttrsToDictionary m)
+        | DocList l -> A(L = ResizeArray(List.map mapAttrValue l), IsLSet = true)
+        | DocMap m -> A(M = mapAttrsToDictionary m, IsMSet = true)
 
     and mapAttr (Attr (name, value)) = name, mapAttrValue value
 


### PR DESCRIPTION
## Proposed Changes

Set IsLSet and IsMSet properties of AttributeValue in case of DocList and DocMap. It makes DynamoDb SDK understand type of the AttributeValue in case of empty lists and maps.

Otherwise an exception is rised during a put request.

## Types of changes

What types of changes does your code introduce to DynamoDb.Ok?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Build and tests pass locally
- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have added necessary documentation (if appropriate)

## Further comments

